### PR TITLE
Add support for empty cells, useful for part-time employees.

### DIFF
--- a/src/data/results-display.js
+++ b/src/data/results-display.js
@@ -106,7 +106,9 @@
     if (type.startsWith("0.5") || type.startsWith("1/2") || type.startsWith("0,5")) {
       nbHours = 4;
     }
-    type = /[A-Z]+/.exec(type.toUpperCase())[0];
+    if (type) {
+      type = /[A-Z]+/.exec(type.toUpperCase())[0];
+    }
 
     const day = state.weeks[weekId][dayId];
     day.type = type;


### PR DESCRIPTION
At the moment, when a cell is left empty, there's a JS error. On the next succeeding cell update, all empty cells will get back to their previous state. What's more, the "time worked" count doesn't get updated. I'm hoping this will fix this issue (as far as I understand the code), but I haven't been able to test it. I'd welcome help about testing and releasing this feature, as it would be pretty useful for part-time employees. :-)