### PR TITLE
Count non-worked days as "jours ouvrés".

### DIFF
--- a/src/data/form-interaction.js
+++ b/src/data/form-interaction.js
@@ -10,7 +10,7 @@ attachInputHandler();
 attachEmptyCellHandler();
 
 function attachInputHandler() {
-  table.addEventListener('input', Utils.throttle((e) => onThrottledInput(e, updateModel), 2000));
+  table.addEventListener('input', Utils.throttle((e) => onThrottledInput(e, updateModel), 800));
 }
 
 function attachEmptyCellHandler() {

--- a/src/data/results-display.js
+++ b/src/data/results-display.js
@@ -10,13 +10,16 @@
     ptoSummary: new Template('form-summary-template')
   };
 
-  var WORKING_DAY_TYPES = ['JT', 'CP', 'JRTT', 'M', 'CS'];
+  // '-' is a type used for part-time employees to indicate non-working
+  // days, so that those days are still counted as "jours ouvrés".
+  var WORKING_DAY_TYPES = ['-', 'JT', 'CP', 'JRTT', 'M', 'CS'];
 
   var ptoTable = document.querySelector('.worked-days-table tbody');
   var ptoSummaryTable = document.querySelector('.summary');
 
   var DEFAULT_SUMMARY_VALUES = {
     totalWorkingDays: 0,
+    '-': 0,
     JT: 0,
     JF: 0,
     M: 0,


### PR DESCRIPTION
This is important for part-time employees, without this option to use a dash to represent non-worked days, the count of "jours ouvrés" is incorrect.